### PR TITLE
Potential fix for code scanning alert no. 3: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/core/master/src/main/java/org/drftpd/master/slavemanagement/RemoteSlave.java
+++ b/src/core/master/src/main/java/org/drftpd/master/slavemanagement/RemoteSlave.java
@@ -279,7 +279,7 @@ public class RemoteSlave extends ExtendedTimedStats implements Runnable, Compara
             throw new SlaveUnavailableException();
         }
         int throughputUp = 0;
-        int throughputDown = 0;
+        long throughputDown = 0;
         int transfersUp = 0;
         int transfersDown = 0;
         long bytesReceived;


### PR DESCRIPTION
Potential fix for [https://github.com/siosios/drftpd3/security/code-scanning/3](https://github.com/siosios/drftpd3/security/code-scanning/3)

To fix this issue, the type of `throughputDown` should be changed from `int` to `long`. This will eliminate the implicit narrowing conversion during the compound assignment (`+=`) operation and prevent potential data loss or overflow.

#### Steps to fix:
1. Change the declaration of `throughputDown` on line 282 from `int` to `long`.
2. Ensure that all other references to `throughputDown` in the method `getSlaveStatus()` are compatible with the updated type.
3. No changes are needed for the `transfer.getXferSpeed()` method, as it already returns a `long`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
